### PR TITLE
able to give team a name, handles moves info on get/post

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -3,29 +3,29 @@ import axios from "axios";
 import SearchBar from "./SearchBar";
 import Pokedex from "./Pokedex";
 import Container from "react-bootstrap/Container";
-import { Pokemon } from "./lib/pokemon";
+import { Pokemon, Move } from "./lib/pokemon";
 
-class Move {
-  constructor(
-    name=undefined, 
-    levelLearned=undefined, 
-    learnMethod=undefined,
-    power=undefined, 
-    accuracy=undefined, 
-    pp=undefined, 
-    dmgClass=undefined, 
-    type=undefined,
-    ){
-    this.name = name;
-    this.levelLearned = levelLearned;
-    this.learnMethod = learnMethod;
-    this.power = power;
-    this.accuracy = accuracy;
-    this.pp = pp;
-    this.dmgClass = dmgClass;
-    this.type = type;
-  }
-}
+// class Move {
+//   constructor(
+//     name=undefined, 
+//     levelLearned=undefined, 
+//     learnMethod=undefined,
+//     power=undefined, 
+//     accuracy=undefined, 
+//     pp=undefined, 
+//     dmgClass=undefined, 
+//     type=undefined,
+//     ){
+//     this.name = name;
+//     this.levelLearned = levelLearned;
+//     this.learnMethod = learnMethod;
+//     this.power = power;
+//     this.accuracy = accuracy;
+//     this.pp = pp;
+//     this.dmgClass = dmgClass;
+//     this.type = type;
+//   }
+// }
 
 class Main extends React.Component{
   constructor(props){
@@ -43,32 +43,6 @@ class Main extends React.Component{
       searchInput: event.target.value.toLowerCase()
     })
   }
-
-  // handleSearch = async (event) => {
-  //   event.preventDefault();
-  //   this.setState({
-  //     searchError: null
-  //   })
-  //   try {
-  //     let request = {
-  //       url: `https://pokeapi.co/api/v2/pokemon/${this.state.searchInput}`,
-  //       method: 'GET'
-  //     }
-
-  //     let response = await axios(request);
-
-  //     console.log(response.data);
-
-  //     this.setState({
-  //       searchResult: response.data
-  //     })
-  //   } catch (err) {
-  //     console.log(err);
-  //     this.setState({
-  //       searchError: err
-  //     })
-  //   }
-  // }
 
   newHandleSearch = async (event) => {
     // prevents page from reloading on  search 'submit'
@@ -96,6 +70,7 @@ class Main extends React.Component{
             }
           })
         })
+        // if there are no moves from gen9, get gen8 moves instead
         if (moveArr.length === 0) {
           response.data.moves.forEach(element => {
             element.version_group_details.forEach(vgDetail => {

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -14,13 +14,6 @@ class SearchBar extends React.Component {
     }
   }
 
-  // handleSubmitForm = (event) => {
-  //   event.preventDefault();
-  //   this.props.handleSearch(event);
-  //   console.log(document.getElementById('search_input'))
-  //   document.getElementById('search_input').value = '';
-  // }
-
   render() {
     return(
       <Container>

--- a/src/lib/pokemon.js
+++ b/src/lib/pokemon.js
@@ -45,3 +45,25 @@ export class AbilityInfo {
     this.isHidden = isHidden;
   }
 }
+
+export class Move {
+  constructor(
+    name=undefined, 
+    levelLearned=undefined, 
+    learnMethod=undefined,
+    power=undefined, 
+    accuracy=undefined, 
+    pp=undefined, 
+    dmgClass=undefined, 
+    type=undefined,
+    ){
+    this.name = name;
+    this.levelLearned = levelLearned;
+    this.learnMethod = learnMethod;
+    this.power = power;
+    this.accuracy = accuracy;
+    this.pp = pp;
+    this.dmgClass = dmgClass;
+    this.type = type;
+  }
+}


### PR DESCRIPTION
1. Added ability to give team a name before saving to database.

2. Unable to save all moves for every pokemon to the database > DB rejects because object is too large.
- Because of this, when saving to DB we have to clear the pokemon's `move` property and only save the 4 moves used in battle as `battleMoves`.
- However, when loading a team from the DB to the client, we need to re-get all of the pokemon's moves again so that the user can select from them in case they want to make a change to the `battleMoves` property.

3. When loading a team, the team name and the team id is set to component state